### PR TITLE
fix: isAllowed 로컬스토리지로 관리

### DIFF
--- a/components/ui/AlarmBtn.tsx
+++ b/components/ui/AlarmBtn.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AlarmPopUp from "./AlarmPopUp";
 import NotAllowedBell from "../icons/NotAllowedBell";
 import AllowedBell from "../icons/AllowedBell";
@@ -15,9 +15,20 @@ export default function AlarmBtn({ memberId }: AlarmBtnProps) {
   const [isAllowed, setIsAllowed] = useState<boolean>(false);
   const [alarmLoading, setAlarmLoading] = useState<boolean>(false);
 
+  useEffect(() => {
+    const saved = localStorage.getItem(`isAllowed_${memberId}`);
+    if (saved !== null) {
+      setIsAllowed(JSON.parse(saved));
+    }
+  }, [memberId]);
+
   const handleClickBell = () => {
     setShowPopUp(!showPopUp);
   };
+
+  useEffect(() => {
+    localStorage.setItem(`isAllowed_${memberId}`, JSON.stringify(isAllowed));
+  }, [isAllowed, memberId]);
 
   return (
     <div className="flex items-center" onClick={handleClickBell}>


### PR DESCRIPTION
- AlarmBtn에서 isAllowed를 로컬스토리지로 관리해 useEffect로 렌더링될때마다 state값을 갱신하도록 수정했습니다.